### PR TITLE
Add markdown-it dependency to package.json and update pnpm-lock.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "markdown-it": "^14.1.0",
     "@ag-grid-community/client-side-row-model": "^32.3.3",
     "@ag-grid-community/core": "^32.3.3",
     "@ag-grid-community/styles": "^33.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       luxon:
         specifier: ^3.6.1
         version: 3.6.1
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.1.0
       string-strip-html:
         specifier: ^13.4.8
         version: 13.4.12


### PR DESCRIPTION
- Added markdown-it version 14.1.0 to package.json to support markdown parsing.
- Updated pnpm-lock.yaml to reflect the new dependency, ensuring consistent package management.